### PR TITLE
docs(readme): include template with rationale + translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ ADR example templates that we have collected on the net:
 
   * [ADR template using Planguage](adr_template_using_planguage.md) (more quality assurance oriented)
 
+  * [ADR template by Paulo Merson](https://github.com/pmerson/ADR-template) (includes a rationale section, plus translated versions)
+
 
 ## Teamwork advice
 


### PR DESCRIPTION
This suggestion adds a fairly well used template by Paulo Merson (co-author of [_Documenting Software Architectures, Second Edition_](https://www.informit.com/store/documenting-software-architectures-views-and-beyond-9780321552686)).

This templates main addition is a _Rationale_ section, plus some translated versions (spanish, portuguese, chinese).