### PR TITLE
Fix links for ADR example templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,13 +220,13 @@ ADR example templates that we have collected on the net:
 
   * [ADR template by Jeff Tyree and Art Akerman](templates/decision_record_template_by_jeff_tyree_and_art_akerman/index.md) (more sophisticated)
 
-  * [ADR template for Alexandrian pattern](template/decision_record_template_for_alexandrian_pattern/index.md) (simple with context specifics)
+  * [ADR template for Alexandrian pattern](templates/decision_record_template_for_alexandrian_pattern/index.md) (simple with context specifics)
 
-  * [ADR template for business case](template/decision_record_template_for_business_case/index.md) (more MBA-oriented, with costs, SWOT, and more opinions)
+  * [ADR template for business case](templates/decision_record_template_for_business_case/index.md) (more MBA-oriented, with costs, SWOT, and more opinions)
 
-  * [ADR template MADR](template/decision_record_template_madr/index.md) (more Markdown)
+  * [ADR template MADR](templates/decision_record_template_madr/index.md) (more Markdown)
 
-  * [ADR template using Planguage](template/decision_record_template_using_planguage/index.md) (more quality assurance oriented)
+  * [ADR template using Planguage](templates/decision_record_template_using_planguage/index.md) (more quality assurance oriented)
 
 
 ## Teamwork advice


### PR DESCRIPTION
Hey there 👋🏼 

Thank you for maintaining this repo! 

It looks like there are more broken linkes to the ADR templates.

I've updated the links to reflect those changes.
